### PR TITLE
Select first valid choice if an invalid value is passed to the enum editor

### DIFF
--- a/data/qmltoolbox/qml/QmlToolbox/PropertyEditor/EditorEnum.qml
+++ b/data/qmltoolbox/qml/QmlToolbox/PropertyEditor/EditorEnum.qml
@@ -33,6 +33,9 @@ Editor
         if (status.hasOwnProperty('choices')) {
             input.model = status.choices;
             input.currentIndex = status.choices.indexOf(status.value);
+            if (input.currentIndex < 0) {
+                input.currentIndex = 0;
+            }
         } else {
             input.model = null;
             input.currentIndex = -1;


### PR DESCRIPTION
This avoids invalid values and the need to explicitly set a valid value when configuring a property (for example [here](https://github.com/cginternals/gloperate/blob/master/source/examples/demo-stages-plugins/ColorGradientDemo.cpp#L76) in gloperate).

Or is setting an invalid choice intentionally possible to achieve a blank ComboBox?