### PR TITLE
Add spinbox

### DIFF
--- a/data/qmltoolbox/qml/QmlToolbox/Controls/+qt54/SpinBox.qml
+++ b/data/qmltoolbox/qml/QmlToolbox/Controls/+qt54/SpinBox.qml
@@ -19,7 +19,7 @@ SpinBox
     property alias realTo:       spinbox.maximumValue
     property alias realStepSize: spinbox.stepSize
 
-    property int scaleFactor:    1 ///< For compatibility to implementation based on QtQuick Controls 2.0
+    property int scaleFactor: 1 ///< For compatibility to implementation based on QtQuick Controls 2.0
 
     DebugItem
     {

--- a/data/qmltoolbox/qml/QmlToolbox/Controls/+qt54/SpinBox.qml
+++ b/data/qmltoolbox/qml/QmlToolbox/Controls/+qt54/SpinBox.qml
@@ -1,0 +1,27 @@
+
+import QtQuick.Controls 1.0
+
+import QmlToolbox.Base 1.0
+
+
+/**
+*  SpinBox
+*
+*  SpinBox input for selecting a number
+*
+*  Implementation of ComboBox using Controls 1.0
+*/
+SpinBox
+{
+    id: spinbox
+
+    property alias realFrom:     spinbox.minimumValue
+    property alias realTo:       spinbox.maximumValue
+    property alias realStepSize: spinbox.stepSize
+
+    property int scaleFactor:    1 ///< For compatibility to implementation based on QtQuick Controls 2.0
+
+    DebugItem
+    {
+    }
+}

--- a/data/qmltoolbox/qml/QmlToolbox/Controls/SpinBox.qml
+++ b/data/qmltoolbox/qml/QmlToolbox/Controls/SpinBox.qml
@@ -1,0 +1,49 @@
+
+import QtQuick 2.4
+import QtQuick.Controls 2.0
+
+import QmlToolbox.Base 1.0
+
+
+/**
+*  SpinBox
+*
+*  SpinBox input for selecting a number
+*
+*  Default implementation of ComboBox using Controls 2.0
+*/
+SpinBox 
+{
+    id: spinbox
+
+    property int decimals:      0    ///< Number of decimals in the spin box
+
+    property real realFrom:     0.0  ///< Minimum number
+    property real realTo:       99.0 ///< Maximum number
+    property real realStepSize: 1.0  ///< To set a custom step size
+
+    property real scaleFactor:  Math.pow(10, spinbox.decimals)
+
+    from: realFrom * scaleFactor
+    to: realTo * scaleFactor
+    stepSize: realStepSize * scaleFactor
+
+    editable: true
+
+    DebugItem
+    {
+    }
+
+    validator: DoubleValidator {
+        bottom: Math.min(spinbox.from, spinbox.to)
+        top:  Math.max(spinbox.from, spinbox.to)
+    }
+
+    textFromValue: function(value, locale) {
+        return Number(value / scaleFactor).toLocaleString(locale, 'f', spinbox.decimals)
+    }
+
+    valueFromText: function(text, locale) {
+        return Number.fromLocaleString(locale, text) * scaleFactor
+    }
+}

--- a/data/qmltoolbox/qml/QmlToolbox/Controls/SpinBox.qml
+++ b/data/qmltoolbox/qml/QmlToolbox/Controls/SpinBox.qml
@@ -24,8 +24,8 @@ SpinBox
 
     property real scaleFactor:  Math.pow(10, spinbox.decimals)
 
-    from: realFrom * scaleFactor
-    to: realTo * scaleFactor
+    from:     realFrom * scaleFactor
+    to:       realTo * scaleFactor
     stepSize: realStepSize * scaleFactor
 
     editable: true
@@ -34,16 +34,19 @@ SpinBox
     {
     }
 
-    validator: DoubleValidator {
+    validator: DoubleValidator
+    {
         bottom: Math.min(spinbox.from, spinbox.to)
-        top:  Math.max(spinbox.from, spinbox.to)
+        top:    Math.max(spinbox.from, spinbox.to)
     }
 
-    textFromValue: function(value, locale) {
-        return Number(value / scaleFactor).toLocaleString(locale, 'f', spinbox.decimals)
+    textFromValue: function(value, locale)
+    {
+        return Number(value / scaleFactor).toLocaleString(locale, 'f', spinbox.decimals);
     }
 
-    valueFromText: function(text, locale) {
-        return Number.fromLocaleString(locale, text) * scaleFactor
+    valueFromText: function(text, locale)
+    {
+        return Number.fromLocaleString(locale, text) * scaleFactor;
     }
 }

--- a/data/qmltoolbox/qml/QmlToolbox/Controls/qmldir
+++ b/data/qmltoolbox/qml/QmlToolbox/Controls/qmldir
@@ -15,11 +15,12 @@ Pane              1.0 Pane.qml
 Panel             1.0 Panel.qml
 Popup             1.0 Popup.qml
 RadioButton       1.0 RadioButton.qml
+RangeSlider       1.0 RangeSlider.qml
 ScrollArea        1.0 ScrollArea.qml
 ScrollBar         1.0 ScrollBar.qml
 Shortcut          1.0 Shortcut.qml
 Slider            1.0 Slider.qml
-RangeSlider       1.0 RangeSlider.qml
+SpinBox           1.0 SpinBox.qml
 StatusBar         1.0 StatusBar.qml
 Switch            1.0 Switch.qml
 TextArea          1.0 TextArea.qml

--- a/data/qmltoolbox/qml/QmlToolbox/PropertyEditor/EditorProxy.qml
+++ b/data/qmltoolbox/qml/QmlToolbox/PropertyEditor/EditorProxy.qml
@@ -31,16 +31,20 @@ Editor
         // Destroy old editor
         // editor.destroy();
 
+        var isNumber = status.type === 'int' || status.type === 'float';
+        var isEnum = status.type === 'enum' || (status.type === 'string' && status.hasOwnProperty('choices'));
+        var useSpinBox = status.hasOwnProperty('asSpinBox') && status.asSpinBox === true;
+
         // Choose editor
         var editorType = editorNone;
-             if (status.type === 'string' && status.hasOwnProperty('choices')) editorType = editorEnum;
-        else if (status.type === 'string')                                     editorType = editorString;
-        else if (status.type === 'filename')                                   editorType = editorFilename;
-        else if (status.type === 'bool')                                       editorType = editorBool;
-        else if (status.type === 'int' || status.type === 'float')             editorType = editorNumber;
-        else if (status.type === 'color')                                      editorType = editorColor;
-        else if (status.type === 'enum')                                       editorType = editorEnum;
-        else if (status.type === 'range')                                      editorType = editorRange;
+             if (isEnum)                     editorType = editorEnum;
+        else if (status.type === 'string')   editorType = editorString;
+        else if (status.type === 'filename') editorType = editorFilename;
+        else if (status.type === 'bool')     editorType = editorBool;
+        else if (isNumber && useSpinBox)     editorType = editorSpinbox;
+        else if (isNumber)                   editorType = editorNumber;
+        else if (status.type === 'color')    editorType = editorColor;
+        else if (status.type === 'range')    editorType = editorRange;
         if (!editorType) return;
 
         // Create editor
@@ -51,6 +55,7 @@ Editor
     Component { id: editorFilename; EditorFilename { anchors.fill: parent; properties: item.properties; path: item.path; slot: item.slot; status: item.status } }
     Component { id: editorBool;     EditorBool     { anchors.fill: parent; properties: item.properties; path: item.path; slot: item.slot; status: item.status } }
     Component { id: editorNumber;   EditorNumber   { anchors.fill: parent; properties: item.properties; path: item.path; slot: item.slot; status: item.status } }
+    Component { id: editorSpinbox;  EditorSpinbox  { anchors.fill: parent; properties: item.properties; path: item.path; slot: item.slot; status: item.status } }
     Component { id: editorColor;    EditorColor    { anchors.fill: parent; properties: item.properties; path: item.path; slot: item.slot; status: item.status } }
     Component { id: editorEnum;     EditorEnum     { anchors.fill: parent; properties: item.properties; path: item.path; slot: item.slot; status: item.status } }
     Component { id: editorRange;    EditorRange    { anchors.fill: parent; properties: item.properties; path: item.path; slot: item.slot; status: item.status } }

--- a/data/qmltoolbox/qml/QmlToolbox/PropertyEditor/EditorProxy.qml
+++ b/data/qmltoolbox/qml/QmlToolbox/PropertyEditor/EditorProxy.qml
@@ -31,6 +31,7 @@ Editor
         // Destroy old editor
         // editor.destroy();
 
+        // Check data type
         var isNumber = status.type === 'int' || status.type === 'float';
         var isEnum = status.type === 'enum' || (status.type === 'string' && status.hasOwnProperty('choices'));
         var useSpinBox = status.hasOwnProperty('asSpinBox') && status.asSpinBox === true;

--- a/data/qmltoolbox/qml/QmlToolbox/PropertyEditor/EditorSpinbox.qml
+++ b/data/qmltoolbox/qml/QmlToolbox/PropertyEditor/EditorSpinbox.qml
@@ -1,0 +1,65 @@
+
+import QtQuick 2.4
+
+import QmlToolbox.Controls 1.0
+
+
+/**
+*  EditorNumber
+*
+*  Editor for properties of type 'int', 'float', etc. with a spin box
+*/
+Editor
+{
+    id: item
+
+    implicitWidth:  input.implicitWidth
+    implicitHeight: input.implicitHeight
+
+    SpinBox 
+    {
+        id: input
+
+        anchors.fill: parent
+
+        onValueChanged:
+        {
+            if (!internal.noUpdate)
+            {
+                item.properties.setValue(item.path, item.slot, value / input.scaleFactor);
+            }
+        }
+    }
+
+    onStatusChanged:
+    {
+        internal.noUpdate = true;
+
+        if (status.hasOwnProperty('decimals')) {
+            input.decimals = status.decimals;
+        }
+
+        if (status.hasOwnProperty('stepSize')) {
+            input.realStepSize = status.stepSize;
+        }
+
+        if (status.hasOwnProperty('minimumValue')) {
+            input.realFrom = status.minimumValue;
+        }
+
+        if (status.hasOwnProperty('maximumValue')) {
+            input.realTo = status.maximumValue;
+        }
+
+        input.value = status.value * input.scaleFactor;
+
+        internal.noUpdate = false;
+    }
+
+    QtObject
+    {
+        id: internal
+
+        property bool noUpdate: false
+    }
+}

--- a/data/qmltoolbox/qml/QmlToolbox/PropertyEditor/EditorSpinbox.qml
+++ b/data/qmltoolbox/qml/QmlToolbox/PropertyEditor/EditorSpinbox.qml
@@ -5,7 +5,7 @@ import QmlToolbox.Controls 1.0
 
 
 /**
-*  EditorNumber
+*  EditorSpinbox
 *
 *  Editor for properties of type 'int', 'float', etc. with a spin box
 */

--- a/data/qmltoolbox/qml/QmlToolbox/PropertyEditor/EditorSpinbox.qml
+++ b/data/qmltoolbox/qml/QmlToolbox/PropertyEditor/EditorSpinbox.qml
@@ -51,7 +51,7 @@ Editor
             input.realTo = status.maximumValue;
         }
 
-        input.value = status.value * input.scaleFactor;
+        input.value = Math.round(status.value * input.scaleFactor);
 
         internal.noUpdate = false;
     }

--- a/data/qmltoolbox/qml/QmlToolbox/PropertyEditor/qmldir
+++ b/data/qmltoolbox/qml/QmlToolbox/PropertyEditor/qmldir
@@ -9,6 +9,7 @@ EditorString   1.0 EditorString.qml
 EditorFilename 1.0 EditorFilename.qml
 EditorBool     1.0 EditorBool.qml
 EditorNumber   1.0 EditorNumber.qml
+EditorSpinbox  1.0 EditorSpinbox.qml
 EditorColor    1.0 EditorColor.qml
 EditorEnum     1.0 EditorEnum.qml
 EditorRange    1.0 EditorRange.qml

--- a/data/qmltoolbox/qml/examples/uiconcept/DemoPropertyInterface.qml
+++ b/data/qmltoolbox/qml/examples/uiconcept/DemoPropertyInterface.qml
@@ -119,11 +119,11 @@ QtObject
         {
             var inputs = stage.inputs;
 
-            inputs[1].value = value;
+            inputs[2].value = value;
 
             stage.inputs = inputs;
 
-            propertyInterface.slotChanged('root', 'Text' , inputs[1]);
+            propertyInterface.slotChanged('root', 'Text' , inputs[2]);
         }
 
         if (path == 'root' && slot == 'Style')
@@ -132,11 +132,11 @@ QtObject
 
             var mapping = {'red': '#FF0000', 'yellow': '#FFFF00', 'green' : '#00FF00'};
 
-            inputs[5].value = mapping[value];
+            inputs[6].value = mapping[value];
 
             stage.inputs = inputs;
 
-            propertyInterface.slotChanged('root', 'Color' , inputs[5]);
+            propertyInterface.slotChanged('root', 'Color' , inputs[6]);
         }
 
         if (path == 'root' && slot == 'Number')
@@ -168,18 +168,18 @@ QtObject
 
             inputs[0].choices = choices;
             inputs[0].value   = mode;
-            inputs[1].value   = text;
-            inputs[2].value   = val;
-            inputs[4].value   = color;
-            inputs[5].value   = text;
+            inputs[2].value   = text;
+            inputs[3].value   = val;
+            inputs[6].value   = color;
+            inputs[7].value   = text;
 
             stage.inputs = inputs;
 
             propertyInterface.slotChanged('root', 'Mode',   inputs[0]);
-            propertyInterface.slotChanged('root', 'Text',   inputs[1]);
-            propertyInterface.slotChanged('root', 'Number', inputs[2]);
-            propertyInterface.slotChanged('root', 'Color' , inputs[4]);
-            propertyInterface.slotChanged('root', 'Filename', inputs[5]);
+            propertyInterface.slotChanged('root', 'Text',   inputs[2]);
+            propertyInterface.slotChanged('root', 'Number', inputs[3]);
+            propertyInterface.slotChanged('root', 'Color' , inputs[6]);
+            propertyInterface.slotChanged('root', 'Filename', inputs[7]);
         }
 
         if (path == 'root' && slot == 'Number2')
@@ -188,11 +188,11 @@ QtObject
 
             var text = '' + value;
 
-            inputs[1].value = text;
+            inputs[2].value = text;
 
             stage.inputs = inputs;
 
-            propertyInterface.slotChanged('root', 'Text', inputs[1]);
+            propertyInterface.slotChanged('root', 'Text', inputs[2]);
         }
     }
 
@@ -407,7 +407,7 @@ QtObject
         {
             var inputs = stage.inputs;
 
-            var value = (inputs[2].value + 1) % 100;
+            var value = (inputs[3].value + 1) % 100;
             propertyInterface.setValue('root', 'Number', value);
         }
     }

--- a/data/qmltoolbox/qml/examples/uiconcept/DemoPropertyInterface.qml
+++ b/data/qmltoolbox/qml/examples/uiconcept/DemoPropertyInterface.qml
@@ -181,6 +181,19 @@ QtObject
             propertyInterface.slotChanged('root', 'Color' , inputs[4]);
             propertyInterface.slotChanged('root', 'Filename', inputs[5]);
         }
+
+        if (path == 'root' && slot == 'Number2')
+        {
+            var inputs = stage.inputs;
+
+            var text = '' + value;
+
+            inputs[1].value = text;
+
+            stage.inputs = inputs;
+
+            propertyInterface.slotChanged('root', 'Text', inputs[1]);
+        }
     }
 
     // Internals
@@ -244,6 +257,17 @@ QtObject
                 maximumValue: 100,
                 value: 20,
                 updateOnDrag: true
+            },
+
+            {
+                name: 'Number2',
+                type: 'float',
+                minimumValue: 0.0,
+                maximumValue: 5.0,
+                decimals: 2,
+                value: 1.0,
+                asSpinBox: true,
+                stepSize: 0.1
             },
 
             {

--- a/data/qmltoolbox/qml/examples/uitest/Main.qml
+++ b/data/qmltoolbox/qml/examples/uitest/Main.qml
@@ -202,6 +202,26 @@ ApplicationWindow
                 {
                     Layout.alignment: Qt.AlignRight
 
+                    text: "SpinBox"
+                }
+
+                RowLayout
+                {
+                    SpinBox
+                    {
+                        id: spinBox
+                    }
+
+                    Label
+                    {
+                        text: spinBox.value
+                    }
+                }
+
+                Label
+                {
+                    Layout.alignment: Qt.AlignRight
+
                     text: "Switch"
                 }
 


### PR DESCRIPTION
This PR adds a SpinBox editor for numbers, tested for Qt 5.4 and 5.7.

If the option `asSpinBox` is set to `true` for an `int` or a `float`, a SpinBox is used instead of a Slider.
The options are similar to those of a Slider (`minimumValue`, `maximumValue`,`value`). 
Number of decimals can be configured with (`decimals`), and `stepSize` can be set.
The Slider option `updateOnDrag` does not exist.