### PR TITLE
Improve scripting console

### DIFF
--- a/data/qmltoolbox/qml/QmlToolbox/Components/ConsolePrompt.qml
+++ b/data/qmltoolbox/qml/QmlToolbox/Components/ConsolePrompt.qml
@@ -169,7 +169,7 @@ Control
         }
     }
 
-    Item
+    QtObject
     {
         id: filter
 

--- a/data/qmltoolbox/qml/QmlToolbox/Components/ConsolePrompt.qml
+++ b/data/qmltoolbox/qml/QmlToolbox/Components/ConsolePrompt.qml
@@ -23,7 +23,7 @@ Control
     signal submitted(string command)
 
     // List of auto-completion words (array of strings)
-    property alias keywords: autocomplete.model
+    property alias keywords: filter.model
 
     // Height of the text element
     property real textHeight: input.height
@@ -67,7 +67,11 @@ Control
 
         Keys.onTabPressed:
         {
-            autocomplete.open();
+            filter.update();
+            if (autocomplete.model.length > 0)
+            {
+                autocomplete.open();
+            }
         }
 
         Keys.onEnterPressed:
@@ -154,8 +158,56 @@ Control
 
         onSelected:
         {
-            input.insert(input.length, model[index]);
+            input.remove(filter.startIndex, filter.endIndex);
+            input.insert(filter.startIndex, model[index]);
             input.forceActiveFocus();
+        }
+
+        onClosed:
+        {
+            input.forceActiveFocus();
+        }
+    }
+
+    Item
+    {
+        id: filter
+
+        property var model: []
+
+        property int startIndex: 0 ///< save start index of currently typed word
+        property int endIndex:   0 ///< save end index of currently typed word
+
+        onModelChanged:
+        {
+            autocomplete.model = filter.model;
+        }
+
+        function update()
+        {
+            startIndex = input.cursorPosition;
+            while(startIndex > 0 && input.text.charAt(startIndex - 1).match(/\w/))
+            {
+                startIndex -= 1;
+            }
+
+            endIndex = input.cursorPosition;
+            while(endIndex < input.text.length && input.text.charAt(endIndex).match(/\w/))
+            {
+                endIndex += 1;
+            }
+
+            var pattern = input.text.substr(startIndex, endIndex - startIndex);
+
+            var filtered = [];
+            for (var i in filter.model)
+            {
+                if (filter.model[i].indexOf(pattern) > -1)
+                {
+                    filtered.push(filter.model[i]);
+                }
+            }
+            autocomplete.model = filtered;
         }
     }
 }

--- a/data/qmltoolbox/qml/QmlToolbox/Components/ScriptConsole.qml
+++ b/data/qmltoolbox/qml/QmlToolbox/Components/ScriptConsole.qml
@@ -54,4 +54,20 @@ ColumnLayout
     {
         log.output(text, type);
     }
+
+    // Transform anything into a nice representation
+    function prettyPrint(something)
+    {
+        if (something === null)
+        {
+            return null;
+        }
+
+        if (typeof something === 'object')
+        {
+            return JSON.stringify(something);
+        }
+
+        return something.toString();
+    }
 }

--- a/data/qmltoolbox/qml/examples/uiconcept/Main.qml
+++ b/data/qmltoolbox/qml/examples/uiconcept/Main.qml
@@ -337,9 +337,9 @@ ApplicationWindow
                 scriptConsole.output("> " + command + "\n");
                 var res = eval(command);
 
-                if (res != undefined)
+                if (res !== undefined)
                 {
-                    console.log(res);
+                    console.log(scriptConsole.prettyPrint(res));
                 }
             }
         }


### PR DESCRIPTION
Changes to improve usability of the scripting console:

- If auto completion is activated while typing part of a word, the current word (alphanumeric characters and `_`) is used for filtering the auto completion, auto completion replaces the partially typed word
- The JSON representation of objects (e.g. `{"key": 42}`) is printed instead of `[Object object]`
- Closing auto completion (e.g. escape) returns focus to console input