### PR TITLE
Various

### DIFF
--- a/data/qmltoolbox/qml/QmlToolbox/Base/StyleDefault.qml
+++ b/data/qmltoolbox/qml/QmlToolbox/Base/StyleDefault.qml
@@ -73,4 +73,5 @@ Item
     property color pipelineLineColorDefault:     '#000000' // Color of connections
     property color pipelineLineColorHighlighted: '#6688c8' // Color of connections when highlighted
     property color pipelineLineColorSelected:    '#c83366' // Color of connections when selected
+    property color pipelineLineColorFeedback:    '#afafaf' // Color of feedback connections
 }

--- a/data/qmltoolbox/qml/QmlToolbox/Base/StyleDefault.qml
+++ b/data/qmltoolbox/qml/QmlToolbox/Base/StyleDefault.qml
@@ -68,7 +68,8 @@ Item
 
     property real  pipelineSlotSize:             20        // Diameter of slots
     property color pipelineSlotColorIn:          '#ffffff' // Color of input slots
-    property color pipelineSlotColorOut:         '#cafd00' // Color of output slots
+    property color pipelineSlotColorOut:         '#ffffff' // Color of output slots
+    property color pipelineSlotColorOutRequired: '#cafd00' // Color of required output slots
 
     property color pipelineLineColorDefault:     '#000000' // Color of connections
     property color pipelineLineColorHighlighted: '#6688c8' // Color of connections when highlighted

--- a/data/qmltoolbox/qml/QmlToolbox/PipelineEditor/Connectors.qml
+++ b/data/qmltoolbox/qml/QmlToolbox/PipelineEditor/Connectors.qml
@@ -62,20 +62,24 @@ Item
                 var splitPath = path.split('.');
                 return splitPath[splitPath.length - 1];
             };
+            var isEqual = function (path, slot, combinedPath) {
+                return path == getPath(combinedPath) && slot == getSlot(combinedPath);
+            }
 
             // Get all stages of the pipeline and the pipeline itself
             var stages = [];
 
             stages.push(path);
 
-            var pipeline = properties.getStage(path);
+            var pipelineInfo = properties.getStage(path);
 
-            for (var i in pipeline.stages)
+            for (var i in pipelineInfo.stages)
             {
-                stages.push(path + '.' + pipeline.stages[i]);
+                stages.push(path + '.' + pipelineInfo.stages[i]);
             }
 
             // Get connectors
+            var pipeline = connectors.pipeline;
             for (var i in stages)
             {
                 // Get stage
@@ -91,13 +95,18 @@ Item
                     var to   = connection.to;
 
                     // Draw connection
-                    var p0 = connectors.pipeline.getSlotPos(getPath(from), getSlot(from));
-                    var p1 = connectors.pipeline.getSlotPos(getPath(to), getSlot(to));
+                    var p0 = pipeline.getSlotPos(getPath(from), getSlot(from));
+                    var p1 = pipeline.getSlotPos(getPath(to), getSlot(to));
 
                     if (p0 != null && p1 != null)
                     {
                         // Highlight the connection if its input or output slot is selected
-                        var status = (connectors.pipeline.hoveredElement == from || connectors.pipeline.hoveredElement == to) ? 1 : 0;
+                        var status = 0;
+                        if (isEqual(pipeline.hoveredPath, pipeline.hoveredSlot, from) ||
+                            isEqual(pipeline.hoveredPath, pipeline.hoveredSlot, to))
+                        {
+                            status = 1;
+                        }
 
                         drawConnector(ctx, p0, p1, status);
                     }
@@ -105,17 +114,17 @@ Item
             }
 
             // Draw interactive connector
-            if (connectors.pipeline.selectedOutput != '')
+            if (pipeline.selectedOutput != '')
             {
-                var p0 = connectors.pipeline.getSlotPos(connectors.pipeline.selectedPath, connectors.pipeline.selectedOutput);
-                var p1 = { x: connectors.pipeline.mouseX, y: connectors.pipeline.mouseY };
+                var p0 = pipeline.getSlotPos(pipeline.selectedPath, pipeline.selectedOutput);
+                var p1 = { x: pipeline.mouseX, y: pipeline.mouseY };
                 drawConnector(ctx, p0, p1, 2);
             }
 
-            if (connectors.pipeline.selectedInput != '')
+            if (pipeline.selectedInput != '')
             {
-                var p0 = { x: connectors.pipeline.mouseX, y: connectors.pipeline.mouseY };
-                var p1 = connectors.pipeline.getSlotPos(connectors.pipeline.selectedPath, connectors.pipeline.selectedInput);
+                var p0 = { x: pipeline.mouseX, y: pipeline.mouseY };
+                var p1 = pipeline.getSlotPos(pipeline.selectedPath, pipeline.selectedInput);
                 drawConnector(ctx, p0, p1, 2);
             }
         }

--- a/data/qmltoolbox/qml/QmlToolbox/PipelineEditor/Connectors.qml
+++ b/data/qmltoolbox/qml/QmlToolbox/PipelineEditor/Connectors.qml
@@ -91,8 +91,10 @@ Item
                 {
                     // Get connection
                     var connection = connections[j];
-                    var from = connection.from;
-                    var to   = connection.to;
+
+                    var from     = connection.from;
+                    var to       = connection.to;
+                    var feedback = connection.feedback || false;
 
                     // Draw connection
                     var p0 = pipeline.getSlotPos(getPath(from), getSlot(from));
@@ -101,7 +103,7 @@ Item
                     if (p0 != null && p1 != null)
                     {
                         // Highlight the connection if its input or output slot is selected
-                        var status = 0;
+                        var status = feedback ? 3 : 0;
                         if (isEqual(pipeline.hoveredPath, pipeline.hoveredSlot, from) ||
                             isEqual(pipeline.hoveredPath, pipeline.hoveredSlot, to))
                         {
@@ -151,6 +153,7 @@ Item
             var color = Ui.style.pipelineLineColorDefault;
             if (status == 1) color = Ui.style.pipelineLineColorHighlighted;
             if (status == 2) color = Ui.style.pipelineLineColorSelected;
+            if (status == 3) color = Ui.style.pipelineLineColorFeedback;
 
             ctx.strokeStyle = color;
             ctx.fillStyle   = color;

--- a/data/qmltoolbox/qml/QmlToolbox/PipelineEditor/OutputSlot.qml
+++ b/data/qmltoolbox/qml/QmlToolbox/PipelineEditor/OutputSlot.qml
@@ -82,7 +82,7 @@ Item
             height:                 item.radius
 
             radius:       width / 2.0
-            color:        item.selected ? Ui.style.pipelineLineColorSelected : (item.hovered ? Ui.style.pipelineLineColorHighlighted : item.color)
+            color:        item.selected ? Ui.style.pipelineLineColorSelected : (item.hovered ? Ui.style.pipelineLineColorHighlighted : (status !== null && status.required ? Ui.style.pipelineSlotColorOutRequired : item.color))
             border.color: item.borderColor
             border.width: item.borderWidth
 

--- a/data/qmltoolbox/qml/QmlToolbox/PipelineEditor/Pipeline.qml
+++ b/data/qmltoolbox/qml/QmlToolbox/PipelineEditor/Pipeline.qml
@@ -200,8 +200,8 @@ Item
         }
 
         // Add pseudo stages for inputs and outputs of the pipeline itself
-        addInputStageItem (pipeline.path, 'Inputs',    20, 150);
-        addOutputStageItem(pipeline.path, 'Outputs', 1200, 150);
+        addInputStageItem (pipeline.path, 'Inputs',  20, 150);
+        addOutputStageItem(pipeline.path, 'Outputs', x,  150);
 
         // Do the layout
         computeLayout();
@@ -395,7 +395,33 @@ Item
     */
     function computeLayout()
     {
-        // [TODO]
+        // ToDo: Implment force directed layout instead
+        var startX = 120;
+        var marginX = 250;
+        var topY = 120;
+        var bottomY = 500;
+
+        var stageOrder = [];
+        for (var name in stageItems)
+        {
+            stageOrder.push({name: name, x: stageItems[name].x});
+        }
+        stageOrder.sort(function (a, b) {return a.x - b.x});
+
+        var x = startX;
+        var isTop = true;
+        for (var i in stageOrder)
+        {
+            var stage = stageItems[stageOrder[i].name];
+
+            stage.x = x;
+            stage.y = isTop ? topY : bottomY;
+
+            x += stage.width + marginX;
+            isTop = !isTop;
+        }
+
+        connectors.requestPaint();
     }
 
     /**

--- a/data/qmltoolbox/qml/QmlToolbox/PipelineEditor/Pipeline.qml
+++ b/data/qmltoolbox/qml/QmlToolbox/PipelineEditor/Pipeline.qml
@@ -15,6 +15,8 @@ Item
 {
     id: pipeline
 
+    signal stageCreated(string path) ///< Signals creation of a new stage item after the pipeline was loaded
+
     // Options
     property var    properties: null ///< Interface for accessing the actual properties
     property string path:       ''   ///< Path in the pipeline hierarchy (e.g., 'pipeline')
@@ -103,7 +105,7 @@ Item
                 {
                     return function()
                     {
-                        pipeline.createStage(type, type);
+                        pipeline.createStage(type, type, menu.x, menu.y);
                     };
                 };
 
@@ -372,13 +374,15 @@ Item
     *  @param[in] name
     *    Name of stage
     */
-    function createStage(className, name)
+    function createStage(className, name, x, y)
     {
         // Create stage
         var realName = properties.createStage(pipeline.path, className, name);
 
         // Create stage item
-        addStageItem(pipeline.path + '.' + realName, realName, 100, 100);
+        addStageItem(pipeline.path + '.' + realName, realName, x, y);
+
+        stageCreated(pipeline.path + '.' + realName);
     }
 
     /**

--- a/data/qmltoolbox/qml/QmlToolbox/PipelineEditor/Pipeline.qml
+++ b/data/qmltoolbox/qml/QmlToolbox/PipelineEditor/Pipeline.qml
@@ -203,8 +203,20 @@ Item
         addInputStageItem (pipeline.path, 'Inputs',  20, 150);
         addOutputStageItem(pipeline.path, 'Outputs', x,  150);
 
-        // Do the layout
-        computeLayout();
+        // Hack: layout after 5 ms to ensure loading of stages is finished
+        function Timer() {
+            return Qt.createQmlObject("import QtQuick 2.0; Timer {}", pipeline);
+        }
+        function delay(delayTime, cb) {
+            var timer = new Timer();
+            timer.interval = delayTime;
+            timer.repeat = false;
+            timer.triggered.connect(cb);
+            timer.start();
+        }
+        delay(10, function() {
+            computeLayout();
+        });
 
         // Redraw connections
         connectors.requestPaint();
@@ -391,34 +403,138 @@ Item
     }
 
     /**
+    *  Compute ranks in half ordered graph
+    */
+    function computeRanks()
+    {
+        var getPath = function (path) {
+            var splitPath = path.split('.');
+            splitPath.splice(splitPath.length - 1, 1);
+            return splitPath.join('.');
+        };
+
+        // build the empty graph
+        var graph = {};
+        var inverseGraph = {};
+        var pathToName = {};
+        for (var name in stageItems)
+        {
+            graph[stageItems[name].path] = [];
+            inverseGraph[stageItems[name].path] = [];
+            pathToName[stageItems[name].path] = name;
+        }
+        pathToName["root"] = "Outputs";
+
+        // insert edges
+        for (var name in stageItems)
+        {
+            var connections = properties.getConnections(stageItems[name].path);
+            for (var i in connections)
+            {
+                var fromPath = getPath(connections[i].from);
+                var toPath = getPath(connections[i].to);
+
+                if (fromPath == "root")
+                {
+                    // ignore connections from root (inputs will be leftmost)
+                    // this lets the algorithm start at the output node
+                    continue;
+                }
+
+                if (graph[fromPath].indexOf(toPath) < 0)
+                {
+                    graph[fromPath].push(toPath);
+                }
+
+                if (inverseGraph[toPath].indexOf(fromPath) < 0)
+                {
+                    inverseGraph[toPath].push(fromPath);
+                }
+            }
+        }
+
+        var ranks = [];
+        var toRemove = [];
+        while (Object.keys(graph).length > 0)
+        {
+            for (var path in graph)
+            {
+                if (graph[path].length === 0)
+                {
+                    toRemove.push(path);
+                }
+            }
+
+            if (toRemove.length === 0)
+            {
+                console.log("circular graph detected, abort layout process.");
+                break;
+            }
+
+            var names = [];
+            for (var i in toRemove)
+            {
+                names.push(pathToName[toRemove[i]]);
+
+            }
+            ranks.push(names);
+
+            for (var i in toRemove)
+            {
+                var current = toRemove[i];
+                for (var j in inverseGraph[current])
+                {
+                    var predecessor = inverseGraph[current][j];
+                    var edgeNum = graph[predecessor].indexOf(current);
+                    graph[predecessor].splice(edgeNum, 1);
+                }
+                delete graph[current];
+            }
+            toRemove = [];
+        }
+        ranks.push(["Inputs"]);
+
+        return ranks;
+    }
+
+    /**
     *  Compute automatic layout for stages
     */
     function computeLayout()
     {
-        // ToDo: Implment force directed layout instead
         var startX = 120;
-        var marginX = 250;
-        var topY = 120;
-        var bottomY = 500;
-
-        var stageOrder = [];
-        for (var name in stageItems)
-        {
-            stageOrder.push({name: name, x: stageItems[name].x});
-        }
-        stageOrder.sort(function (a, b) {return a.x - b.x});
+        var marginX = 100;
+        var startY = 120;
+        var marginY = 100;
 
         var x = startX;
-        var isTop = true;
-        for (var i in stageOrder)
+
+        var ranks = computeRanks();
+
+        for (var i in ranks)
         {
-            var stage = stageItems[stageOrder[i].name];
+            // go through the computed ranks in reverse order
+            var stages = ranks[ranks.length - i - 1];
 
-            stage.x = x;
-            stage.y = isTop ? topY : bottomY;
+            var maxWidth = 0;
+            for (var j in stages)
+            {
+                var current = stageItems[stages[j]];
 
-            x += stage.width + marginX;
-            isTop = !isTop;
+                maxWidth = Math.max(maxWidth, current.width);
+            }
+
+            var y = startY;
+            for (var j in stages)
+            {
+                var current = stageItems[stages[j]];
+
+                current.x = x + (maxWidth - current.width) / 2;
+                current.y = y;
+
+                y += current.height + marginY;
+            }
+            x += maxWidth + marginX;
         }
 
         connectors.requestPaint();

--- a/data/qmltoolbox/qml/QmlToolbox/PipelineEditor/Pipeline.qml
+++ b/data/qmltoolbox/qml/QmlToolbox/PipelineEditor/Pipeline.qml
@@ -434,9 +434,10 @@ Item
                 var fromPath = getPath(connections[i].from);
                 var toPath = getPath(connections[i].to);
 
-                if (fromPath == "root")
+                if (fromPath == "root" || connections[i].feedback)
                 {
                     // ignore connections from root (inputs will be leftmost)
+                    // and feedback connections
                     // this lets the algorithm start at the output node
                     continue;
                 }

--- a/data/qmltoolbox/qml/QmlToolbox/PipelineEditor/PipelineEditor.qml
+++ b/data/qmltoolbox/qml/QmlToolbox/PipelineEditor/PipelineEditor.qml
@@ -61,4 +61,13 @@ Rectangle
             loaded = true;
         }
     }
+
+    /**
+    *  Update pipeline (reload on different model)
+    */
+    function update()
+    {
+        pipeline.path = "";
+        pipeline.path = "root";
+    }
 }

--- a/data/qmltoolbox/qml/QmlToolbox/PipelineEditor/PipelineEditor.qml
+++ b/data/qmltoolbox/qml/QmlToolbox/PipelineEditor/PipelineEditor.qml
@@ -15,7 +15,8 @@ Rectangle
     id: panel
 
     // Options
-    property var properties: null ///< Interface for communicating with the actual properties
+    property var properties: null     ///< Interface for communicating with the actual properties
+    property var pipeline:   pipeline ///< Interface for communication from root
 
     // Internals
     property bool loaded: false

--- a/data/qmltoolbox/qml/QmlToolbox/PipelineEditor/Stage.qml
+++ b/data/qmltoolbox/qml/QmlToolbox/PipelineEditor/Stage.qml
@@ -379,6 +379,19 @@ Item
     }
 
     /**
+    *  Add custom component to stage body
+    *
+    *  @param[in] component
+    *    The component from which one instance should be added
+    *  @param[in] options
+    *    Options for component creation
+    */
+    function addComponent(component, options)
+    {
+        return component.createObject(inputs, options);
+    }
+
+    /**
     *  Load pipeline
     */
     onPathChanged:

--- a/data/qmltoolbox/qml/QmlToolbox/PipelineEditor/Stage.qml
+++ b/data/qmltoolbox/qml/QmlToolbox/PipelineEditor/Stage.qml
@@ -57,7 +57,7 @@ Item
 
         MenuItem
         {
-            text: 'Add Input'
+            text: 'Add Input...'
 
             onTriggered:
             {
@@ -69,13 +69,23 @@ Item
 
         MenuItem
         {
-            text: 'Add Output'
+            text: 'Add Output...'
 
             onTriggered:
             {
                 dialog.slotType = 'Output';
                 dialog.setChoices(properties.getSlotTypes(stage.path));
                 dialog.open();
+            }
+        }
+
+        MenuItem
+        {
+            text: 'Delete Stage'
+
+            onTriggered:
+            {
+                stage.closed();
             }
         }
     }

--- a/data/qmltoolbox/qml/examples/uiconcept/DemoPropertyInterface.qml
+++ b/data/qmltoolbox/qml/examples/uiconcept/DemoPropertyInterface.qml
@@ -40,6 +40,7 @@ QtObject
             { from: 'root.Number', to: 'root.Stage2.Number' },
             { from: 'root.Stage1.Ok', to: 'root.Stage3.Ok1' },
             { from: 'root.Stage2.Ok', to: 'root.Stage3.Ok2' },
+            { from: 'root.Stage3.OkFeedback', to: 'root.Stage2.FeedbackIn', feedback : true },
             { from: 'root.Stage3.Ok', to: 'root.Ok' }
         ];
     }
@@ -199,19 +200,26 @@ QtObject
     // Internals
     function getSlotInfo(path, slot)
     {
-        for (var i=0; i<propertyInterface.stage.inputs.length; i++)
+        var stage = null;
+
+        if (path == 'root')        stage = propertyInterface.stage;
+        if (path == 'root.Stage1') stage = propertyInterface.stage1;
+        if (path == 'root.Stage2') stage = propertyInterface.stage2;
+        if (path == 'root.Stage3') stage = propertyInterface.stage3;
+
+        for (var i = 0; i < stage.inputs.length; i++)
         {
-            if (propertyInterface.stage.inputs[i].name == slot)
+            if (stage.inputs[i].name === slot)
             {
-                return propertyInterface.stage.inputs[i];
+                return stage.inputs[i];
             }
         }
 
-        for (var i=0; i<propertyInterface.stage.outputs.length; i++)
+        for (var i = 0; i < stage.outputs.length; i++)
         {
-            if (propertyInterface.stage.outputs[i].name == slot)
+            if (stage.outputs[i].name === slot)
             {
-                return propertyInterface.stage.outputs[i];
+                return stage.outputs[i];
             }
         }
 
@@ -332,7 +340,8 @@ QtObject
             {
                 name: 'Ok',
                 type: 'bool',
-                value: true
+                value: true,
+                required: true
             }
         ]
 
@@ -349,6 +358,11 @@ QtObject
                 name: 'Number',
                 type: 'int',
                 value: 0
+            },
+            {
+                name: 'FeedbackIn',
+                type: 'bool',
+                value: true
             }
         ]
 
@@ -356,7 +370,8 @@ QtObject
             {
                 name: 'Ok',
                 type: 'bool',
-                value: true
+                value: true,
+                required: true
             }
         ]
 
@@ -374,7 +389,6 @@ QtObject
                 type: 'bool',
                 value: true
             },
-
             {
                 name: 'Ok2',
                 type: 'bool',
@@ -385,6 +399,12 @@ QtObject
         property var outputs: [
             {
                 name: 'Ok',
+                type: 'bool',
+                value: true,
+                required: true
+            },
+            {
+                name: 'OkFeedback',
                 type: 'bool',
                 value: true
             }

--- a/data/qmltoolbox/qml/examples/uiconcept/Main.qml
+++ b/data/qmltoolbox/qml/examples/uiconcept/Main.qml
@@ -379,13 +379,11 @@ ApplicationWindow
     // Hides the pipeline editor
     function hideEditor()
     {
-        if (settings.editor === "internal")
-        {
-            mainView.visible             = true;
-            internalPipelineView.visible = false;
-        } else {
-            popoutWindow.hide();
-        }
+        // hide internal editor
+        mainView.visible             = true;
+        internalPipelineView.visible = false;
+        // hide external editor
+        popoutWindow.hide();
     }
 
     // Bottom Panel
@@ -452,6 +450,11 @@ ApplicationWindow
         onDebugModeChanged:
         {
             Ui.debugMode = debugMode;
+        }
+
+        onEditorChanged:
+        {
+            hideEditor();
         }
     }
 

--- a/data/qmltoolbox/qml/examples/uiconcept/Main.qml
+++ b/data/qmltoolbox/qml/examples/uiconcept/Main.qml
@@ -328,6 +328,9 @@ ApplicationWindow
 
         title: 'Pipeline Editor'
 
+        minimumWidth:  750
+        minimumHeight: 550
+
         PipelineView
         {
             id: externalPipelineView

--- a/data/qmltoolbox/qml/examples/uiconcept/Main.qml
+++ b/data/qmltoolbox/qml/examples/uiconcept/Main.qml
@@ -1,6 +1,7 @@
 
 import QtQuick 2.4
 import QtQuick.Layouts 1.1
+import QtQuick.Window 2.2
 
 import QmlToolbox.Base           1.0
 import QmlToolbox.Controls       1.0
@@ -153,8 +154,7 @@ ApplicationWindow
 
                         onTriggered:
                         {
-                            pipelineView.visible = true;
-                            mainView.visible     = false;
+                            showEditor();
                         }
                     }
                 }
@@ -300,18 +300,88 @@ ApplicationWindow
         // Pipeline view
         PipelineView
         {
-            id: pipelineView
+            id: internalPipelineView
 
             anchors.fill: parent
             visible:      false
 
             properties: demoProperties
 
+            toggleButton: 'Open in new window'
+
             onClosed:
             {
-                mainView.visible     = true;
-                pipelineView.visible = false;
+                hideEditor();
             }
+
+            onToggled:
+            {
+                toggleEditor();
+            }
+        }
+    }
+
+    // Pipeline view in separate window
+    Window
+    {
+        id: popoutWindow
+
+        title: 'Pipeline Editor'
+
+        PipelineView
+        {
+            id: externalPipelineView
+
+            anchors.fill: parent
+
+            properties: demoProperties
+
+            toggleButton: 'Show inside main window'
+
+            onClosed:
+            {
+                hideEditor();
+            }
+
+            onToggled:
+            {
+                toggleEditor();
+            }
+        }
+    }
+
+    // Toggles between internal and external pipeline editor
+    function toggleEditor()
+    {
+        hideEditor();
+        settings.editor = (settings.editor === "internal" ? "external" : "internal");
+        showEditor();
+    }
+
+    // Shows the pipeline editor
+    function showEditor()
+    {
+        if (settings.editor === "internal")
+        {
+            internalPipelineView.visible = true;
+            mainView.visible             = false;
+            internalPipelineView.load();
+        } else {
+            popoutWindow.showMaximized();
+            popoutWindow.raise();
+            externalPipelineView.load();
+        }
+    }
+
+    // Hides the pipeline editor
+    function hideEditor()
+    {
+        if (settings.editor === "internal")
+        {
+            mainView.visible             = true;
+            internalPipelineView.visible = false;
+        } else {
+            popoutWindow.hide();
         }
     }
 
@@ -374,6 +444,7 @@ ApplicationWindow
         property int    height:        600
         property bool   debugMode:     false
         property string panelPosition: 'left'
+        property string editor:        'internal'
 
         onDebugModeChanged:
         {

--- a/data/qmltoolbox/qml/examples/uiconcept/PipelineView.qml
+++ b/data/qmltoolbox/qml/examples/uiconcept/PipelineView.qml
@@ -11,8 +11,10 @@ Item
     id: page
 
     signal closed()
+    signal toggled()
 
-    property var properties: null ///< Interface for communicating with the actual properties
+    property var properties:      null  ///< Interface for communicating with the actual properties
+    property string toggleButton: ""    ///< Description of the toggle state button
 
     implicitWidth:  pipelineEditor.implicitWidth
     implicitHeight: pipelineEditor.implicitHeight
@@ -38,9 +40,24 @@ Item
                 page.closed();
             }
         }
+
+        Button
+        {
+            text: page.toggleButton
+            visible: page.toggleButton === "" ? false : true
+
+            anchors.top:     parent.top
+            anchors.right:   parent.right
+            anchors.margins: Ui.style.paddingMedium
+
+            onClicked:
+            {
+                page.toggled();
+            }
+        }
     }
 
-    Component.onCompleted:
+    function load()
     {
         pipelineEditor.load();
     }

--- a/data/qmltoolbox/qml/examples/uiconcept/SettingsPage.qml
+++ b/data/qmltoolbox/qml/examples/uiconcept/SettingsPage.qml
@@ -87,6 +87,26 @@ Item
                         settings.panelPosition = position;
                     }
                 }
+
+                Label
+                {
+                    Layout.alignment: Qt.AlignRight
+
+                    text: 'Pipeline Editor'
+                }
+
+                ComboBox
+                {
+                    model: [ 'external', 'internal' ]
+
+                    currentIndex: model.indexOf(settings.editor)
+
+                    onActivated:
+                    {
+                        var editor = model[index];
+                        settings.editor = editor;
+                    }
+                }
             }
         }
     }


### PR DESCRIPTION
This PR contains various improvements:

- Outputs can be marked as required, non-required outputs will be shown in white instead of the current default green
- Highlighting of active connections fixed
- Simple algorithm for creating a layout which uses the vertical space available in a better way with a topological sort
- Pipeline Editor can be configured to be in a popup window in addition to the usual internal view 
- Deleting stages via context menu is possible
- Connections can be marked as feedback connections (reverse to pipeline order) and are displayed differently and ignored for layout purposes
- Enables integration and configuration of custom stages through a new signal and exposing the pipeline object to the editor

Current Hack:

- Layout process is done 10ms after the pipeline editor is first opened. I did not find another reliable way to call the layout function after all stage items received their actual sizes, which is needed for any nice layout function. This could probable be improved somehow.